### PR TITLE
[FEAT] 생활뉴스 목록 조회 내용 추가

### DIFF
--- a/src/main/java/com/example/olebackend/converter/NewsConverter.java
+++ b/src/main/java/com/example/olebackend/converter/NewsConverter.java
@@ -24,8 +24,10 @@ public class NewsConverter {
 
         return NewsResponse.getNewsPreviewDTO.builder()
                 .id(news.getId())
-                .title(news.getTitle())
+                .createdAt(news.getCreatedAt())
                 .category(news.getCategory().toString())
+                .title(news.getTitle())
+                .content(news.getContent())
                 .author(news.getAuthor())
                 .filePath(file != null ? file.getPath() : null)
                 .build();

--- a/src/main/java/com/example/olebackend/web/dto/NewsResponse.java
+++ b/src/main/java/com/example/olebackend/web/dto/NewsResponse.java
@@ -16,10 +16,13 @@ public class NewsResponse {
     public static class getNewsPreviewDTO {
 
         Long id;
-        String title;
+        LocalDateTime createdAt;
         String category;
+        String title;
+        String content;
         String author;
         String filePath;
+
 
     }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -85,10 +85,10 @@ INSERT INTO community_comment(content, community_id, member_id) VALUES ("1번글
 INSERT INTO community_comment(content, community_id, member_id) VALUES ("2번글 댓글",2, 3);
 INSERT INTO community_comment(content, community_id, member_id) VALUES ("3번글 댓글",3, 1);
 
-INSERT INTO news(category, author, content, title) VALUES ('BOARD', '친절한 쩡아쌤', '생활뉴스 글1', '생활뉴스 제목1');
-INSERT INTO news(category, author, content, title) VALUES ('HEALTH', '친절한 쩡아쌤', '생활뉴스 글2', '생활뉴스 제목2');
-INSERT INTO news(category, author, content, title) VALUES ('LIFE', '친절한 쩡아쌤', '생활뉴스 글3', '생활뉴스 제목3');
-INSERT INTO news(category, author, content, title) VALUES ('RECRUIT', '친절한 쩡아쌤', '생활뉴스 글4', '생활뉴스 제목4');
+INSERT INTO news(created_at, category, author, content, title) VALUES ('2024-01-26 23:50:19.000000', 'BOARD', '친절한 쩡아쌤', '생활뉴스 글1', '생활뉴스 제목1');
+INSERT INTO news(created_at, category, author, content, title) VALUES ('2024-01-27 23:50:19.000000', 'HEALTH', '친절한 쩡아쌤', '생활뉴스 글2', '생활뉴스 제목2');
+INSERT INTO news(created_at, category, author, content, title) VALUES ('2024-01-25 23:50:19.000000','LIFE', '친절한 쩡아쌤', '생활뉴스 글3', '생활뉴스 제목3');
+INSERT INTO news(created_at, category, author, content, title) VALUES ('2024-01-23 23:50:19.000000','RECRUIT', '친절한 쩡아쌤', '생활뉴스 글4', '생활뉴스 제목4');
 
 INSERT INTO file(name, lesson_id, member_id, news_id) VALUES ('뉴스 테스트', null, null, 1);
 INSERT INTO file(name, path, represent, lesson_id, member_id, news_id) VALUES ('test', 'resources/static/test.png', FALSE, null, null, 1);


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 올래생활뉴스 목록 조회시 보여지는 정보를 추가했습니다. (생성일, 글 본문)
- 더미데이터에 생성일을 추가했습니다.


## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #84 
