### PR TITLE
[FEAT] 올래생활뉴스 카테고리별 조회 추가

### DIFF
--- a/src/main/java/com/example/olebackend/repository/NewsRepository.java
+++ b/src/main/java/com/example/olebackend/repository/NewsRepository.java
@@ -1,9 +1,17 @@
 package com.example.olebackend.repository;
 
+import com.example.olebackend.domain.Community;
 import com.example.olebackend.domain.News;
+import com.example.olebackend.domain.enums.CommunityCategory;
+import com.example.olebackend.domain.enums.NewsCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NewsRepository extends JpaRepository<News, Long> {
+
+    Page<News> findNewsByCategory(NewsCategory category, PageRequest pageRequest);
+
 }

--- a/src/main/java/com/example/olebackend/service/NewsService.java
+++ b/src/main/java/com/example/olebackend/service/NewsService.java
@@ -1,7 +1,9 @@
 package com.example.olebackend.service;
 
 import com.example.olebackend.apiPayLoad.exception.GeneralException;
+import com.example.olebackend.domain.Community;
 import com.example.olebackend.domain.News;
+import com.example.olebackend.domain.enums.NewsCategory;
 import com.example.olebackend.repository.NewsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,9 +23,16 @@ public class NewsService {
 
     private final NewsRepository newsRepository;
 
-    public Page<News> getNewsList(Integer page) {
-        Page<News> newsList = newsRepository.findAll(PageRequest.of(page - 1, 10));
+    public Page<News> getNewsList(NewsCategory category, Integer page) {
 
+
+        Page<News> newsList;
+
+        if (category == null) {
+            newsList = newsRepository.findAll(PageRequest.of(page - 1, 10));
+        } else {
+            newsList = newsRepository.findNewsByCategory(category, PageRequest.of(page - 1, 10));
+        }
         // 전체 페이지 수 이상의 값을 입력했을 때
         if (page > newsList.getTotalPages()) {
             throw new GeneralException(PAGE_NOT_FOUND);

--- a/src/main/java/com/example/olebackend/web/controller/NewsController.java
+++ b/src/main/java/com/example/olebackend/web/controller/NewsController.java
@@ -3,6 +3,7 @@ package com.example.olebackend.web.controller;
 import com.example.olebackend.apiPayLoad.ApiResponse;
 import com.example.olebackend.converter.NewsConverter;
 import com.example.olebackend.domain.News;
+import com.example.olebackend.domain.enums.NewsCategory;
 import com.example.olebackend.service.NewsService;
 import com.example.olebackend.web.dto.NewsResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,8 +28,9 @@ public class NewsController {
     @Parameters({
             @Parameter(name = "page", description = "페이지 번호이며, 1페이지부터 시작입니다."),
     })
-    public ApiResponse<NewsResponse.getNewsListDTO> getNewsList(@RequestParam(required = false, defaultValue = "1") Integer page) {
-        Page<News> newsList = newsService.getNewsList(page);
+    public ApiResponse<NewsResponse.getNewsListDTO> getNewsList(@RequestParam(required = false) NewsCategory category,
+                                                                @RequestParam(required = false, defaultValue = "1") Integer page) {
+        Page<News> newsList = newsService.getNewsList(category, page);
         return ApiResponse.onSuccess(NewsConverter.toNewsListDTO(newsList));
     }
 


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 올래생활뉴스에서 게시물 조회시, '공지사항', '건강정보', '생활정보', '취업정보'를 구분하여 게시물을 조회할 수 있는 기능을 추가하였습니다.


## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #89 
