### PR TITLE
[FIX] 교육 이미지 null 오류 수정

### DIFF
--- a/src/main/java/com/example/olebackend/converter/LessonConverter.java
+++ b/src/main/java/com/example/olebackend/converter/LessonConverter.java
@@ -85,17 +85,22 @@ public class LessonConverter {
 
         List<File> fileList = lesson.getFileList();
 
+        String filePath = null;
+
         File file = fileList.stream()
                 .filter(File::isRepresent)
                 .findFirst()
                 .orElse(null);
 
+        if (file != null) {
+            filePath = file.getPath();
+        }
 
         return LessonResponse.getLessonOrderByCriteriaDTO.builder()
                 .title(lesson.getTitle())
                 .currentCount(lesson.getCurrentCount())
                 .place(lesson.getPlace())
-                .filePath(file.getPath())
+                .filePath(filePath)
                 .build();
     }
 


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 교육 조회시 이미지가 null일 경우 발생하는 오류를 처리하는 로직을 수정하였습니다.


## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #108 
