### PR TITLE
fix: oauth2 관련 가져오는 정보 및 redirecturi 설정

### DIFF
--- a/src/main/java/com/example/olebackend/domain/Member.java
+++ b/src/main/java/com/example/olebackend/domain/Member.java
@@ -25,32 +25,32 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private String name; // 이름
 
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private String email; // 이메일
 
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private String phoneNum; // 전화번호
 
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private String address; // 주소
 
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private Long birthYear; // 생년
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private Gender gender; // 성별
 
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private boolean mailAgree; // 메일 수신 동의
 
-    @Column(nullable = false)
+//    @Column(nullable = false)
     private boolean smsAgree; // 문자 수신 동의
 
 

--- a/src/main/java/com/example/olebackend/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/example/olebackend/oauth2/OAuthAttributes.java
@@ -47,7 +47,7 @@ public class OAuthAttributes {
                 .socialType(socialType)
                 .socialId(oauth2UserInfo.getId())
                 .email(UUID.randomUUID() + "@socialUser.com")
-                .name(oauth2UserInfo.getNickname())
+//                .name(oauth2UserInfo.getNickname())
                 .role(Role.GUEST)
                 .build();
     }

--- a/src/main/java/com/example/olebackend/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/example/olebackend/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -32,7 +32,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             if(oAuth2User.getRole() == Role.GUEST){
                 String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
                 response.addHeader(jwtService.getAccessHeader(), "Bearer "+ accessToken);
-                response.sendRedirect("oauth2/sign-up");
+                response.sendRedirect("https://center.pawdlypartners.com/login/oauth2/code/kakao");
 
                 jwtService.sendAccessAndRefreshToken(response, accessToken, null);
             }else{

--- a/src/main/java/com/example/olebackend/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/example/olebackend/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -12,20 +12,20 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo{
         return String.valueOf(attributes.get("id"));
     }
 
-    @Override
-    public String getNickname(){
-        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
-
-        if(account == null){
-            return null;
-        }
-        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
-
-        if(profile == null){
-            return null;
-        }
-        return (String) profile.get("nickname");
-    }
+//    @Override
+//    public String getNickname(){
+//        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+//
+//        if(account == null){
+//            return null;
+//        }
+//        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+//
+//        if(profile == null){
+//            return null;
+//        }
+//        return (String) profile.get("nickname");
+//    }
 //    @Override
 //    public String getEmail(){
 //        Map<String, Object> response = (Map<String, Object>) attributes.get("response");

--- a/src/main/java/com/example/olebackend/oauth2/userinfo/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/example/olebackend/oauth2/userinfo/NaverOAuth2UserInfo.java
@@ -16,15 +16,15 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo{
         return (String) response.get("id");
     }
 
-    @Override
-    public String getNickname(){
-        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
-
-        if(response == null){
-            return null;
-        }
-        return(String) response.get("nickname");
-    }
+//    @Override
+//    public String getNickname(){
+//        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+//
+//        if(response == null){
+//            return null;
+//        }
+//        return(String) response.get("nickname");
+//    }
 //    @Override
 //    public String getEmail(){
 //        Map<String, Object> response = (Map<String, Object>) attributes.get("response");

--- a/src/main/java/com/example/olebackend/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/example/olebackend/oauth2/userinfo/OAuth2UserInfo.java
@@ -8,7 +8,7 @@ public abstract class OAuth2UserInfo {
     }
 
     public abstract String getId();
-    public abstract String getNickname();
+//    public abstract String getNickname();
 //    public abstract String getEmail();
 //    public abstract String getGender();
 


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- oauth 설정 시, 네이버와 카카오로 가져오는 정보 종류의 문제가 있어서, 이를 수정하였습니다.
- 또한, 소셜로그인으로 회원가입 시 생성되는 데이터가 NOT NULL 제약조건에 위배되는 문제가 있어, 이를 해제해줬습니다.
- 소셜로그인 이후 Redirect URI가 없어 오류가 발생, 임시로 카카오에서 제공하는 임의의 URL을 설정해줬습니다.


## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #이슈번호
