### PR TITLE
[FIX] 카테고리별 교육 조회 필터 수정

### DIFF
--- a/src/main/java/com/example/olebackend/repository/LessonRepository.java
+++ b/src/main/java/com/example/olebackend/repository/LessonRepository.java
@@ -14,4 +14,10 @@ import java.util.List;
 public interface LessonRepository extends JpaRepository<Lesson, Long>, JpaSpecificationExecutor<Lesson> {
     Page<Lesson> findBySubCategoryCategoryId(Long categoryId, PageRequest pageRequest);
 
+    List<Lesson> findBySubCategoryCategoryId(Long categoryId);
+
+    @Query("SELECT l FROM Lesson l ORDER BY (l.limitCount / l.currentCount)")
+    Page<Lesson> orderByLimitAndCurrent(List<Lesson> lessonList, PageRequest pageRequest);
+
+
 }

--- a/src/main/java/com/example/olebackend/repository/specification/LessonSpecification.java
+++ b/src/main/java/com/example/olebackend/repository/specification/LessonSpecification.java
@@ -1,6 +1,8 @@
 package com.example.olebackend.repository.specification;
 
+import com.example.olebackend.domain.Category;
 import com.example.olebackend.domain.Lesson;
+import com.example.olebackend.domain.SubCategory;
 import org.springframework.data.jpa.domain.Specification;
 
 import javax.persistence.criteria.*;
@@ -39,11 +41,18 @@ public class LessonSpecification {
                     predicates.add(criteriaBuilder.like(criteriaBuilder.lower(root.get(field.getName())), likePattern));
                 }
             }
-
-            Join<Object, Object> teachersJoin = root.join("lectureTeacherList").join("teacher");
-            predicates.add(criteriaBuilder.like(criteriaBuilder.lower(teachersJoin.get("name")), likePattern));
+//            Join<Lesson, LectureTeacher> lectureTeacherJoin = root.join("lectureTeacherList", JoinType.INNER);
+//            Join<LectureTeacher, Teacher> teacherJoin = lectureTeacherJoin.join("teacher", JoinType.INNER);
+//            predicates.add(criteriaBuilder.like(criteriaBuilder.lower(teacherJoin.get("name")), likePattern));
 
             return criteriaBuilder.or(predicates.toArray(new Predicate[0]));
+        };
+    }
+    public static Specification<Lesson> findByCategoryId(Long categoryId) {
+        return (root, query, criteriaBuilder) -> {
+            Join<Lesson, SubCategory> subCategoryJoin = root.join("subCategory", JoinType.INNER);
+            Join<SubCategory, Category> categoryJoin = subCategoryJoin.join("category", JoinType.INNER);
+            return criteriaBuilder.equal(categoryJoin.get("id"), categoryId);
         };
     }
 

--- a/src/main/java/com/example/olebackend/web/controller/LessonController.java
+++ b/src/main/java/com/example/olebackend/web/controller/LessonController.java
@@ -5,7 +5,6 @@ import com.example.olebackend.apiPayLoad.exception.GeneralException;
 import com.example.olebackend.converter.LessonConverter;
 import com.example.olebackend.domain.Lesson;
 import com.example.olebackend.jwt.service.JwtService;
-import com.example.olebackend.repository.LessonRepository;
 import com.example.olebackend.repository.specification.LessonSpecification;
 import com.example.olebackend.service.LessonService;
 import com.example.olebackend.web.dto.LessonResponse;
@@ -13,19 +12,20 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
-import java.util.Optional;
 
 import static com.example.olebackend.apiPayLoad.code.status.ErrorStatus.KEYWORD_NOT_FOUND;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/lesson")
+@Slf4j
 public class LessonController {
 
     private final LessonService lessonService;
@@ -57,18 +57,16 @@ public class LessonController {
     })
     public ApiResponse<LessonResponse.getLessonListDTO> getLessonListByCategory(@PathVariable Long categoryId,
                                                                                 @RequestParam(required = false, value = "keyword") String keyword,
+                                                                                @RequestParam(required = false, value = "orderBy", defaultValue = "createdAt") String orderCriteria,
                                                                                 @RequestParam(required = false, defaultValue = "1") Integer page) {
         Specification<Lesson> spec = (root, query, criteriaBuilder) -> null;
 
-        // 키워드가 있으면 -> 키워드로 검색하는 spec 추가
+        spec = spec.and(LessonSpecification.findByCategoryId(categoryId));
+
         if (keyword != null) {
             spec = spec.and(LessonSpecification.findByKeyword(keyword));
-
-        } else {
-            spec = null;
         }
-
-        Page<Lesson> lessonList = lessonService.getLessonList(categoryId, spec, page);
+        Page<Lesson> lessonList = lessonService.getLessonList(categoryId, spec, orderCriteria, page);
         return ApiResponse.onSuccess(LessonConverter.toLessonListDTO(lessonList));
 
     }

--- a/src/main/java/com/example/olebackend/web/controller/LessonController.java
+++ b/src/main/java/com/example/olebackend/web/controller/LessonController.java
@@ -60,19 +60,17 @@ public class LessonController {
                                                                                 @RequestParam(required = false, defaultValue = "1") Integer page) {
         Specification<Lesson> spec = (root, query, criteriaBuilder) -> null;
 
-        // 키워드가 있으면 -> 카테고리별로 조회한 교육 리스트 내에서 keyword 포함한 교육 리턴
+        // 키워드가 있으면 -> 키워드로 검색하는 spec 추가
         if (keyword != null) {
             spec = spec.and(LessonSpecification.findByKeyword(keyword));
-            Page<Lesson> lessonList = lessonService.getLessonListBySpecification(categoryId, spec, page);
-            return ApiResponse.onSuccess(LessonConverter.toLessonListDTO(lessonList));
+
+        } else {
+            spec = null;
         }
 
-        // 키워드가 없으면 -> 단순 카테고리별 교육 조회
-        else {
-            Page<Lesson> lessonList = lessonService.getLessonListByCategory(categoryId, page);
-            return ApiResponse.onSuccess(LessonConverter.toLessonListDTO(lessonList));
+        Page<Lesson> lessonList = lessonService.getLessonList(categoryId, spec, page);
+        return ApiResponse.onSuccess(LessonConverter.toLessonListDTO(lessonList));
 
-        }
     }
 
     @GetMapping


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 카테고리별 교육 조회시 최신순, 모집 마감순, 신청자순 필터를 추가하였습니다.
- 기존의 키워드 검색도 조건을 추가하여 필터링 하였습니다.


## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 교육의 강사 이름으로 검색이 되지 않습니다. 다른 조건으로 검색은 모두 가능하고 해당 부분은 추후 수정하겠습니다.


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #179 
